### PR TITLE
feat: support coloros 12 for oneplus devices

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -6,12 +6,18 @@ elif [ -e /product/etc/permissions/services.cn.google.xml ]; then
     origin=/product/etc/permissions/services.cn.google.xml
 elif [ -e /product/etc/permissions/cn.google.services.xml ]; then
     origin=/product/etc/permissions/cn.google.services.xml
+elif [ -e /my_bigball/etc/permissions/oplus_google_cn_gms_features.xml ]; then
+    origin=/my_bigball/etc/permissions/oplus_google_cn_gms_features.xml
 else
     exit 0
 fi
 
 if [[ $origin == *system* ]]; then
     target=$MODPATH$origin
+elif [[ $origin == *my_bigball* ]]; then
+    target=$MODPATH/oplus_google_cn_gms_features.xml
+    echo -e '#!/system/bin/sh\nmount -o ro,bind ${0%/*}/oplus_google_cn_gms_features.xml /my_bigball/etc/permissions/oplus_google_cn_gms_features.xml' > $MODPATH/post-fs-data.sh
+    echo 'sleep 60; umount /my_bigball/etc/permissions/oplus_google_cn_gms_features.xml' > $MODPATH/service.sh
 else
     target=$MODPATH/system$origin
 fi

--- a/customize.sh
+++ b/customize.sh
@@ -17,7 +17,7 @@ if [[ $origin == *system* ]]; then
 elif [[ $origin == *my_bigball* ]]; then
     target=$MODPATH/oplus_google_cn_gms_features.xml
     echo -e '#!/system/bin/sh\nmount -o ro,bind ${0%/*}/oplus_google_cn_gms_features.xml /my_bigball/etc/permissions/oplus_google_cn_gms_features.xml' > $MODPATH/post-fs-data.sh
-    echo 'sleep 60; umount /my_bigball/etc/permissions/oplus_google_cn_gms_features.xml' > $MODPATH/service.sh
+    # echo 'sleep 60; umount /my_bigball/etc/permissions/oplus_google_cn_gms_features.xml' > $MODPATH/service.sh
 else
     target=$MODPATH/system$origin
 fi


### PR DESCRIPTION
Use bind mount to replace color os permission files since it is not in directory that magisk can directly replace. Unmount this file afterwards to avoid magisk being detected by momo somehow.