### PR TITLE
script/customize: Dynamically set product path to avoid mount issues

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -4,6 +4,10 @@ elif [ -e /system/etc/permissions/com.oppo.features.cn_google.xml ]; then
     origin=/system/etc/permissions/com.oppo.features.cn_google.xml
 elif [ -e /vendor/etc/permissions/services.cn.google.xml ]; then
     origin=/vendor/etc/permissions/services.cn.google.xml
+elif [ -e /system/product/etc/permissions/services.cn.google.xml ]; then
+    origin=/product/etc/permissions/services.cn.google.xml
+elif [ -e /system/product/etc/permissions/cn.google.services.xml ]; then
+    origin=/product/etc/permissions/cn.google.services.xml
 elif [ -e /product/etc/permissions/services.cn.google.xml ]; then
     origin=/product/etc/permissions/services.cn.google.xml
 elif [ -e /product/etc/permissions/cn.google.services.xml ]; then


### PR DESCRIPTION
Mounting with mountify (backslashxx/mountify) breaks on /product, and Magic Mount in KSU also fails in some cases.  To ensure compatibility, check if /system/product exists and use it; otherwise, fall back to /product.  This improves compatibility across different mounting systems.