### PR TITLE
替换[[高级语法匹配修复Magisk无法正常匹配

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -19,32 +19,39 @@ for origin in $FILES; do
     [ ! -e "$origin" ] && continue
     found=true
 
-    if [[ $origin == *my_bigball* ]]; then
-        target=$MODPATH/oplus_google_cn_gms_features.xml
-        echo "mount -o ro,bind \${0%/*}/oplus_google_cn_gms_features.xml /my_bigball/etc/permissions/oplus_google_cn_gms_features.xml" >> $MODPATH/post-fs-data.sh
-        need_bind_mount=true
-    elif [[ $origin == *my_product* ]]; then
-        target=$MODPATH/oplus_google_cn_gms_features.xml
-        echo "mount -o ro,bind \${0%/*}/oplus_google_cn_gms_features.xml /my_product/etc/permissions/oplus_google_cn_gms_features.xml" >> $MODPATH/post-fs-data.sh
-        need_bind_mount=true
-    elif [[ $origin == *my_heytap* ]]; then
-        target=$MODPATH/my_heytap_cn_gms_features.xml
-        echo "mount -o ro,bind \${0%/*}/my_heytap_cn_gms_features.xml /my_heytap/etc/permissions/my_heytap_cn_gms_features.xml" >> $MODPATH/post-fs-data.sh
-        need_bind_mount=true
-        if [[ -e /my_heytap/etc/permissions/my_heytap_cn_features.xml ]]; then
-            echo "mount -o ro,bind \${0%/*}/my_heytap_cn_features.xml /my_heytap/etc/permissions/my_heytap_cn_features.xml" >> $MODPATH/post-fs-data.sh
-            heytap_cn_features_orgin=/my_heytap/etc/permissions/my_heytap_cn_features.xml
-            heytap_cn_features_target=$MODPATH/my_heytap_cn_features.xml
-        fi
-    elif [[ $origin == /odm/* ]]; then
-        target=$MODPATH/$(basename $origin)
-        echo "mount -o ro,bind \${0%/*}/$(basename $origin) $origin" >> $MODPATH/post-fs-data.sh
-        need_bind_mount=true
-    elif [[ $origin == *system* ]]; then
-        target=$MODPATH$origin
-    else
-        target=$MODPATH/system$origin
-    fi
+	case "$origin" in
+		*my_bigball*)
+			target=$MODPATH/oplus_google_cn_gms_features.xml
+			echo "mount -o ro,bind \${0%/*}/oplus_google_cn_gms_features.xml /my_bigball/etc/permissions/oplus_google_cn_gms_features.xml" >> $MODPATH/post-fs-data.sh
+			need_bind_mount=true
+			;;
+		*my_product*)
+			target=$MODPATH/oplus_google_cn_gms_features.xml
+			echo "mount -o ro,bind \${0%/*}/oplus_google_cn_gms_features.xml /my_product/etc/permissions/oplus_google_cn_gms_features.xml" >> $MODPATH/post-fs-data.sh
+			need_bind_mount=true
+			;;
+		*my_heytap*)
+			target=$MODPATH/my_heytap_cn_gms_features.xml
+			echo "mount -o ro,bind \${0%/*}/my_heytap_cn_gms_features.xml /my_heytap/etc/permissions/my_heytap_cn_gms_features.xml" >> $MODPATH/post-fs-data.sh
+			need_bind_mount=true
+			if [ -e /my_heytap/etc/permissions/my_heytap_cn_features.xml ]; then
+				echo "mount -o ro,bind \${0%/*}/my_heytap_cn_features.xml /my_heytap/etc/permissions/my_heytap_cn_features.xml" >> $MODPATH/post-fs-data.sh
+				heytap_cn_features_orgin=/my_heytap/etc/permissions/my_heytap_cn_features.xml
+				heytap_cn_features_target=$MODPATH/my_heytap_cn_features.xml
+			fi
+			;;
+		/odm/*)
+			target=$MODPATH/$(basename $origin)
+			echo "mount -o ro,bind \${0%/*}/$(basename $origin) $origin" >> $MODPATH/post-fs-data.sh
+			need_bind_mount=true
+			;;
+		*system*)
+			target=$MODPATH$origin
+			;;
+		*)
+			target=$MODPATH/system$origin
+			;;
+	esac
 
     mkdir -p $(dirname $target)
     cp -f $origin $target
@@ -57,7 +64,7 @@ if $need_bind_mount; then
     sed -i '1i#!/system/bin/sh' $MODPATH/post-fs-data.sh
 fi
 
-if [[ -e "$heytap_cn_features_orgin" ]]; then
+if [ -e "$heytap_cn_features_orgin" ]; then
     mkdir -p $(dirname $heytap_cn_features_target)
     cp -f $heytap_cn_features_orgin $heytap_cn_features_target
     sed -i '/cn.google.services/d' $heytap_cn_features_target


### PR DESCRIPTION
在Magisk30.7中发现小米8e5匹配/odm下文件失效问题，发现走的都是else未匹配到，Magisk默认shell应该是不支持[[匹配，所以使用case替换if [[

已在ksu 3.1和magisk30.7测试可用